### PR TITLE
Refactor histogram fields to include `tdigest` and `legacy` formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,8 +398,8 @@ Generates a dedicated time series data stream containing distribution fields:
 - **Data Stream**: `histograms-samples` (Elasticsearch `index.mode: time_series`)
 - **Dimensions**: `entity.id`
 - **Fields**:
-  - `histogram.tdigest` (`histogram`)
-  - `histogram.hdr` (`histogram`)
+  - `histogram.tdigest` (`tdigest`, document shape `centroids` + `counts`)
+  - `histogram.legacy` (`histogram`, legacy HDR-like)
   - `histogram.exponential` (`exponential_histogram`)
 
 Example document:
@@ -408,10 +408,10 @@ Example document:
   "@timestamp": "2025-01-08T15:30:00.000Z",
   "entity.id": "entity-01",
   "histogram.tdigest": {
-    "values": [12.3, 18.7, 29.1],
+    "centroids": [12.3, 18.7, 29.1],
     "counts": [10, 12, 8]
   },
-  "histogram.hdr": {
+  "histogram.legacy": {
     "values": [10.0, 14.1, 20.0],
     "counts": [5, 15, 10]
   },

--- a/src/formatters/histograms-formatter.ts
+++ b/src/formatters/histograms-formatter.ts
@@ -1,18 +1,21 @@
-import { trace } from '@opentelemetry/api';
-import { HistogramsDocument, HistogramsMetrics } from '../types/histogram-types';
+import { trace } from "@opentelemetry/api";
+import {
+  HistogramsDocument,
+  HistogramsMetrics,
+} from "../types/histogram-types";
 
-const tracer = trace.getTracer('simian-forge');
+const tracer = trace.getTracer("simian-forge");
 
 export class HistogramsFormatter {
   formatMetrics(metrics: HistogramsMetrics): HistogramsDocument[] {
-    return tracer.startActiveSpan('formatMetrics', (span) => {
+    return tracer.startActiveSpan("formatMetrics", (span) => {
       try {
         const doc: HistogramsDocument = {
-          '@timestamp': metrics.timestamp.toISOString(),
-          'entity.id': metrics.entity.id,
-          'histogram.tdigest': metrics.histograms.tdigest,
-          'histogram.hdr': metrics.histograms.hdr,
-          'histogram.exponential': metrics.histograms.exponential
+          "@timestamp": metrics.timestamp.toISOString(),
+          "entity.id": metrics.entity.id,
+          "histogram.tdigest": metrics.histograms.tdigest,
+          "histogram.legacy": metrics.histograms.legacy,
+          "histogram.exponential": metrics.histograms.exponential,
         };
 
         span.setStatus({ code: 1 });
@@ -27,4 +30,3 @@ export class HistogramsFormatter {
     });
   }
 }
-

--- a/src/simulators/histograms-metrics-generator.ts
+++ b/src/simulators/histograms-metrics-generator.ts
@@ -1,24 +1,32 @@
-import { MetricsGenerator } from '../types/simulator-types';
-import { HistogramsConfig, HistogramsMetrics } from '../types/histogram-types';
-import { HistogramsGenerator } from './histograms-generator';
+import { MetricsGenerator } from "../types/simulator-types";
+import { HistogramsConfig, HistogramsMetrics } from "../types/histogram-types";
+import { HistogramsGenerator } from "./histograms-generator";
 
-export class HistogramsMetricsGenerator implements MetricsGenerator<HistogramsConfig, HistogramsMetrics> {
+export class HistogramsMetricsGenerator implements MetricsGenerator<
+  HistogramsConfig,
+  HistogramsMetrics
+> {
   private generator: HistogramsGenerator;
 
   constructor() {
     this.generator = new HistogramsGenerator();
   }
 
-  generateMetrics(config: HistogramsConfig, timestamp: Date): HistogramsMetrics {
+  generateMetrics(
+    config: HistogramsConfig,
+    timestamp: Date,
+  ): HistogramsMetrics {
     return {
       timestamp,
       entity: config,
       histograms: {
         tdigest: this.generator.generateTdigestHistogram(config, timestamp),
-        hdr: this.generator.generateHdrHistogram(config, timestamp),
-        exponential: this.generator.generateExponentialHistogram(config, timestamp)
-      }
+        legacy: this.generator.generateLegacyHistogram(config, timestamp),
+        exponential: this.generator.generateExponentialHistogram(
+          config,
+          timestamp,
+        ),
+      },
     };
   }
 }
-

--- a/src/simulators/histograms-simulator.ts
+++ b/src/simulators/histograms-simulator.ts
@@ -138,17 +138,17 @@ export class HistogramsSimulator extends BaseSimulator<
                 meta: { description: "Entity id" },
               },
               "histogram.tdigest": {
-                type: "histogram",
+                type: "tdigest",
                 time_series_metric: "histogram",
                 meta: {
-                  description: "Tdigest-like histogram",
+                  description: "T-digest histogram (time series)",
                 },
               },
-              "histogram.hdr": {
+              "histogram.legacy": {
                 type: "histogram",
                 time_series_metric: "histogram",
                 meta: {
-                  description: "HDR-like histogram",
+                  description: "Legacy histogram (HDR-like)",
                 },
               },
               "histogram.exponential": {

--- a/src/types/histogram-types.ts
+++ b/src/types/histogram-types.ts
@@ -5,7 +5,7 @@ export interface HistogramsConfig {
    * Kept stable across runs (deterministic per entity).
    */
   distribution: {
-    type: 'lognormal';
+    type: "lognormal";
     /** Typical value (roughly median) */
     median: number;
     /** Spread (higher means heavier tail) */
@@ -17,6 +17,12 @@ export interface HistogramsConfig {
 
 export interface HistogramField {
   values: number[];
+  counts: number[];
+}
+
+/** ES tdigest field format (centroids + counts). */
+export interface TDigestField {
+  centroids: number[];
   counts: number[];
 }
 
@@ -43,17 +49,16 @@ export interface HistogramsMetrics {
   timestamp: Date;
   entity: HistogramsConfig;
   histograms: {
-    tdigest: HistogramField;
-    hdr: HistogramField;
+    tdigest: TDigestField;
+    legacy: HistogramField;
     exponential: ExponentialHistogramField;
   };
 }
 
 export interface HistogramsDocument {
-  '@timestamp': string;
-  'entity.id': string;
-  'histogram.tdigest': HistogramField;
-  'histogram.hdr': HistogramField;
-  'histogram.exponential': ExponentialHistogramField;
+  "@timestamp": string;
+  "entity.id": string;
+  "histogram.tdigest": TDigestField;
+  "histogram.legacy": HistogramField;
+  "histogram.exponential": ExponentialHistogramField;
 }
-


### PR DESCRIPTION
# Histograms: tdigest type and legacy field rename

## Summary

Updates the histograms dataset to align with Elasticsearch’s tdigest time-series support and renames the legacy (HDR-like) histogram field for clarity.

| Before | After |
|--------|--------|
| `histogram.tdigest` (mapping type `histogram`) | `histogram.tdigest` (mapping type **`tdigest`**), document shape **`centroids`** + `counts` |
| `histogram.hdr` (mapping type `histogram`) | **`histogram.legacy`** (mapping type `histogram`) |
| `histogram.exponential` (mapping type `exponential_histogram`) | No change |

## Changes

### T-digest field (`histogram.tdigest`)

- **Mapping**: Field type changed from `histogram` to **`tdigest`** with `time_series_metric: "histogram"`.
- **Document shape**: Uses **`centroids`** and **`counts`** (replacing `values` + `counts`) to match the ES tdigest format.
- **Types**: New `TDigestField` interface; generator returns `{ centroids, counts }`.

### Legacy field (formerly `histogram.hdr`)

- **Field name**: **`histogram.hdr`** → **`histogram.legacy`** in the index and in document output.
- **Mapping**: Still `type: "histogram"` with `time_series_metric: "histogram"`; description set to “Legacy histogram (HDR-like)”.
- **Code**: Method renamed `generateHdrHistogram` → **`generateLegacyHistogram`**; internal property **`hdr`** → **`legacy`** in `HistogramsMetrics.histograms`.

### Exponential histogram

- **No changes** to mapping, document shape, or code.

## Example document (after)

```json
{
  "@timestamp": "2025-01-08T15:30:00.000Z",
  "entity.id": "entity-01",
  "histogram.tdigest": {
    "centroids": [12.3, 18.7, 29.1],
    "counts": [10, 12, 8]
  },
  "histogram.legacy": {
    "values": [10.0, 14.1, 20.0],
    "counts": [5, 15, 10]
  },
  "histogram.exponential": {
    "scale": 8,
    "sum": 1234.0,
    "min": 5.1,
    "max": 420.2,
    "zero": { "threshold": 0, "count": 0 },
    "positive": { "indices": [12, 13, 14], "counts": [20, 7, 3] }
  }
}
```

## How to test

1. `npm run build`
2. `./forge --dataset histograms --count 3 --interval 10s`


## Screenshot

<img width="1722" height="995" alt="image" src="https://github.com/user-attachments/assets/507eb075-bfc8-4392-88f1-5db3d59d8042" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated histogram field naming: "histogram.hdr" renamed to "histogram.legacy"
  * T-digest histogram field now uses centroids and counts structure
  * Updated documentation and example documents to reflect new histogram schema

<!-- end of auto-generated comment: release notes by coderabbit.ai -->